### PR TITLE
Fix/barbs_len

### DIFF
--- a/earthkit/maps/charts/__init__.py
+++ b/earthkit/maps/charts/__init__.py
@@ -267,8 +267,10 @@ class Chart:
         def wrapper(self, data, *args, **kwargs):
             if not isinstance(data, (earthkit.data.core.Base, list, np.ndarray)):
                 data = earthkit.data.from_object(data)
-            if not isinstance(data, earthkit.data.core.Base) or not hasattr(
-                data, "__len__"
+            if (
+                not isinstance(data, earthkit.data.core.Base)
+                or not hasattr(data, "__len__")
+                or method.__name__ in ["barbs"]
             ):
                 data = [data]
 

--- a/earthkit/maps/charts/__init__.py
+++ b/earthkit/maps/charts/__init__.py
@@ -267,10 +267,14 @@ class Chart:
         def wrapper(self, data, *args, **kwargs):
             if not isinstance(data, (earthkit.data.core.Base, list, np.ndarray)):
                 data = earthkit.data.from_object(data)
-            if (
-                not isinstance(data, earthkit.data.core.Base)
-                or not hasattr(data, "__len__")
-                or method.__name__ in ["barbs"]
+
+            if method.__name__ in ["barbs"]:
+                if not isinstance(data, list):
+                    data = [data]
+                data = list(map(earthkit.data.from_object, data))
+
+            elif not isinstance(data, earthkit.data.core.Base) or not hasattr(
+                data, "__len__"
             ):
                 data = [data]
 


### PR DESCRIPTION
When using `.barbs` plotting fails due to length issue from `earthkit.data` wrapper,

Can be fixed by wrapping data with a list. However, there remains an issue with metadata discovery.